### PR TITLE
Update team page to remove dead links

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -19,7 +19,6 @@
   twitter: abrown_dev
   jobtitle: Lead iOS Developer
   image: https://pbs.twimg.com/profile_images/1276258563241979906/qLkXGCM__400x400.jpg
-  site: https://www.swiftcompiled.com/author/alex/
 
 - name: Karim El Khazaani
   twitter: crabdul_
@@ -40,7 +39,7 @@
   site: http://goochgooch.co.uk/posts/
 
 - name: Matt Kinnersley
-  twitter: techwaffler
+  twitter: mattkinnersley_
   jobtitle: Front-end Developer
   image: https://pbs.twimg.com/profile_images/1353630729503203330/ISHIQo1z_400x400.jpg
   site: https://www.techwaffle.dev/


### PR DESCRIPTION
Updating the team page to remove / correct some dead links, as these were reported through our HackOne bug bounty program (for some reason 🤷 ).