### PR TITLE
Fix hyperlinks to the conventions repo

### DIFF
--- a/_posts/2023-06-21-pull-request-conventions.md
+++ b/_posts/2023-06-21-pull-request-conventions.md
@@ -10,11 +10,11 @@ hex: 0e1720
 At Kraken Tech we use GitHub pull requests for our reviews. Over the years we've adopted a
 set of conventions to make sure we get the most out of the reviewing process.
 
-We've recently revamped them and [published them on our public conventions](https://github.com/octoenergy/conventions/blob/master/pull-requests.md).
+We've recently revamped them and [published them on our public conventions](https://github.com/octoenergy/conventions/blob/master/conventions/pull-requests.md).
 Take a look, and feel free to use / fork for your own team.
 
 Here are three of my favourites:
 
-- [Ensure your reviewers have enough context](https://github.com/octoenergy/conventions/blob/master/pull-requests.md#ensure-your-reviewers-have-enough-context)
-- [Do only one thing with each commit](https://github.com/octoenergy/conventions/blob/master/pull-requests.md#do-only-one-thing-with-each-commit)
-- [Keep pull requests small](https://github.com/octoenergy/conventions/blob/master/pull-requests.md#keep-prs-small)
+- [Ensure your reviewers have enough context](https://github.com/octoenergy/conventions/blob/master/conventions/pull-requests.md#ensure-your-reviewers-have-enough-context)
+- [Do only one thing with each commit](https://github.com/octoenergy/conventions/blob/master/conventions/pull-requests.md#do-only-one-thing-with-each-commit)
+- [Keep pull requests small](https://github.com/octoenergy/conventions/blob/master/conventions/pull-requests.md#keep-prs-small)


### PR DESCRIPTION
This change fixes the urls to the convention references, as referenced files were moved to a subfolder (/conventions) in the repository.